### PR TITLE
feat: presence heartbeat, chat overhaul, site-wide UI polish

### DIFF
--- a/app/Dashboard/page.tsx
+++ b/app/Dashboard/page.tsx
@@ -2,18 +2,18 @@
 
 import React, { useEffect } from "react";
 
-import SoundBoard from "../components/SoundBoard";
 import Lead from "../components/Lead";
 import Navbar from "../components/Navbar";
 import PersonalTODO from "../components/PersonalTODO";
 import CommunityConnect from "../components/CommunityConnect";
+import FriendsSection from "../components/FriendsSection";
 
 import authservice from "@/app/auth/firebase-auth";
 
 const Dashboard = () => {
   useEffect(() => {
-    // AuthGuard already handles route-level auth; this is just a no-op
-    // sanity check kept from the original component, ported off Appwrite.
+    // AuthGuard already handles route-level auth; this is just a sanity
+    // check kept from the original Appwrite-era component.
     authservice.checkUser().catch((error) => {
       console.error("Not authenticated", error);
     });
@@ -22,31 +22,19 @@ const Dashboard = () => {
   return (
     <>
       <Navbar />
-      <main className="min-h-screen p-6 dark:bg-[#020612] text-gray-900 dark:text-white">
-        <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
-          {/* Left Column - Leaderboard */}
-          <div className="lg:col-span-1">
-            <div className="bg-white dark:bg-gray-800 rounded-2xl p-4 ">
+      <main className="min-h-screen p-4 md:p-6 dark:bg-[#020612] text-gray-900 dark:text-white">
+        <div className="max-w-7xl mx-auto space-y-6">
+          {/* Top: three equal widgets — social + personal at a glance */}
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 items-start">
+            <div className="bg-white dark:bg-zinc-800 rounded-2xl p-4 shadow-[0_4px_20px_rgba(128,0,255,0.08)]">
               <Lead />
             </div>
+            <FriendsSection />
+            <PersonalTODO />
           </div>
 
-          {/* Middle Column - Community Connect */}
-          <div className="lg:col-span-2">
-            <CommunityConnect />
-          </div>
-
-          {/* Right Column - User Den */}
-          <div className="lg:col-span-1 flex flex-col gap-6">
-            <div className="h-1/2">
-              <PersonalTODO />
-            </div>
-            <div className="h-1/2">
-              <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-md p-4 h-full overflow-hidden flex flex-col">
-                <SoundBoard />
-              </div>
-            </div>
-          </div>
+          {/* Bottom: clans take the full width */}
+          <CommunityConnect />
         </div>
       </main>
     </>

--- a/app/Explore/page.tsx
+++ b/app/Explore/page.tsx
@@ -2,12 +2,22 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useSelector } from "react-redux";
+import Link from "next/link";
 import AOS from "aos";
 import "aos/dist/aos.css";
 
-import { BsFillBarChartFill } from "react-icons/bs";
-import { FaClipboardList } from "react-icons/fa";
-import { CgProfile } from "react-icons/cg";
+import {
+  CheckCircle2,
+  XCircle,
+  TrendingUp,
+  Trophy,
+  Target,
+  ChevronLeft,
+  ChevronRight,
+  Search,
+  CalendarDays,
+  ArrowRight,
+} from "lucide-react";
 
 import Navbar from "../components/Navbar";
 import Footer from "../components/Footer";
@@ -74,7 +84,6 @@ export default function ExplorePage() {
   const [search, setSearch] = useState("");
   const scrollRef = useRef<HTMLDivElement>(null);
 
-  // Questions (for the Topics carousel).
   useEffect(() => {
     AOS.init({ duration: 800, once: true });
     fetch("/api/questions")
@@ -83,7 +92,6 @@ export default function ExplorePage() {
       .catch(() => setQuestions([]));
   }, []);
 
-  // Upcoming quizzes.
   useEffect(() => {
     fetch("/api/quizzes")
       .then((r) => r.json())
@@ -91,7 +99,6 @@ export default function ExplorePage() {
       .catch(() => setQuizzes([]));
   }, []);
 
-  // Current user's submissions (drives "Recent Tests" + Achievements).
   useEffect(() => {
     if (!isLoggedIn || !userData?.email) {
       setSubmissions([]);
@@ -107,7 +114,7 @@ export default function ExplorePage() {
       .catch(() => setSubmissions([]));
   }, [isLoggedIn, userData?.email]);
 
-  // Topics grouping (same logic as before).
+  // Topics grouping.
   const grouped: Record<string, Question[]> = {};
   questions.forEach((q) => {
     if (!q.tags || q.tags.length === 0) {
@@ -119,9 +126,7 @@ export default function ExplorePage() {
     }
   });
 
-  // Recent Tests: dedupe by question so a problem solved 3 times appears
-  // once (latest attempt). /api/user-submissions returns newest-first, so the
-  // first occurrence of each questionId is the latest.
+  // Recent Tests: dedupe by question — newest first.
   const seenQuestionIds = new Set<string>();
   const recentTests: Submission[] = [];
   for (const sub of submissions) {
@@ -129,247 +134,254 @@ export default function ExplorePage() {
     if (seenQuestionIds.has(key)) continue;
     seenQuestionIds.add(key);
     recentTests.push(sub);
-    if (recentTests.length >= 4) break;
+    if (recentTests.length >= 5) break;
   }
 
-  // Stats stay raw: "Submissions" = total attempts, "Pass rate" = passed /
-  // total. These measure activity + attempt quality, not unique problems.
+  // Stats are activity-quality measures, not unique counts.
   const totalSubmissions = submissions.length;
   const passedSubmissions = submissions.filter((s) => s.passed).length;
+  const uniqueSolved = new Set(
+    submissions.filter((s) => s.passed).map((s) => s.questionId)
+  ).size;
   const accuracyPct =
     totalSubmissions > 0
       ? Math.round((passedSubmissions / totalSubmissions) * 100)
       : 0;
+  const totalPoints = submissions.reduce((sum, s) => sum + (s.points || 0), 0);
 
-  const scrollLeft = () => {
-    scrollRef.current?.scrollBy({ left: -300, behavior: "smooth" });
-  };
-  const scrollRight = () => {
-    scrollRef.current?.scrollBy({ left: 300, behavior: "smooth" });
-  };
+  const scrollLeft = () =>
+    scrollRef.current?.scrollBy({ left: -320, behavior: "smooth" });
+  const scrollRight = () =>
+    scrollRef.current?.scrollBy({ left: 320, behavior: "smooth" });
 
   const displayName =
     isLoggedIn && userData?.name ? userData.name : "Welcome";
+
+  const filteredTopics = Object.entries(grouped).filter(([tag]) =>
+    search.trim()
+      ? tag.toLowerCase().includes(search.trim().toLowerCase())
+      : true
+  );
 
   return (
     <>
       <Navbar />
       <div className="min-h-screen text-gray-800 dark:bg-[#020612] dark:text-white transition-all">
-        <main className="p-4 md:p-10">
+        <main className="max-w-7xl mx-auto p-4 md:p-10 space-y-10">
           {/* Header */}
-          <div
-            className="flex flex-col md:flex-row justify-between items-start gap-4"
-            data-aos="fade-down"
-          >
-            <div>
-              <h2 className="text-3xl font-bold">
-                {isLoggedIn ? `Welcome, ${displayName}!` : "Welcome!"}
-              </h2>
-              <p className="text-gray-600 dark:text-gray-400">
-                {isLoggedIn
-                  ? "Here's a snapshot of your activity."
-                  : "Log in to see your personal dashboard."}
-              </p>
-            </div>
-
-            <div className="flex items-center space-x-4 w-full md:w-auto">
-              <input
-                type="text"
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                placeholder="Search topics..."
-                className="px-4 py-2 rounded-full border-2 border-gray-300 dark:border-zinc-600 bg-white dark:bg-zinc-800 focus:outline-none"
-              />
-              <CgProfile className="scale-150 text-gray-700 dark:text-white" />
-            </div>
+          <div data-aos="fade-down">
+            <h2 className="text-3xl md:text-4xl font-bold">
+              {isLoggedIn ? `Welcome, ${displayName}!` : "Welcome!"}
+            </h2>
+            <p className="text-gray-600 dark:text-gray-400 mt-1">
+              {isLoggedIn
+                ? "Here's a snapshot of your activity."
+                : "Log in to see your personal dashboard."}
+            </p>
           </div>
 
-          {/* Main Grid Layout */}
-          <div className="mt-10 grid grid-cols-1 lg:grid-cols-3 gap-8">
-            {/* Left Content */}
-            <div className="lg:col-span-2 space-y-10">
-              {/* Recent Tests */}
+          {/* Stats strip — 4 small cards instead of 2 big ones */}
+          {isLoggedIn && (
+            <div
+              className="grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-4"
+              data-aos="fade-up"
+            >
+              <StatPill
+                icon={TrendingUp}
+                label="Submissions"
+                value={totalSubmissions}
+              />
+              <StatPill
+                icon={Target}
+                label="Pass rate"
+                value={totalSubmissions ? `${accuracyPct}%` : "—"}
+              />
+              <StatPill icon={Trophy} label="Solved" value={uniqueSolved} />
+              <StatPill icon={Trophy} label="Points" value={totalPoints} />
+            </div>
+          )}
+
+          {/* Main two-column layout */}
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 lg:gap-8 items-start">
+            {/* Left column: Recent Tests + Quizzes */}
+            <div className="lg:col-span-2 space-y-8">
+              {/* Recent Tests — list, not grid (works for 1 or 5 items) */}
               <section data-aos="fade-up">
-                <h3 className="text-xl font-semibold mb-4">Recent Tests</h3>
-                {!isLoggedIn ? (
-                  <p className="text-gray-500 dark:text-gray-400">
-                    Log in to see your recent submissions.
-                  </p>
-                ) : recentTests.length === 0 ? (
-                  <div className="bg-white dark:bg-zinc-800 rounded-xl p-6 text-center text-gray-500 dark:text-gray-400 shadow-[0_4px_20px_rgba(128,0,255,0.15)]">
-                    No submissions yet. Head to{" "}
-                    <a
-                      href="/problems"
-                      className="text-blue-600 hover:underline dark:text-blue-400"
+                <div className="flex items-center justify-between mb-3">
+                  <h3 className="text-xl font-semibold">Recent Tests</h3>
+                  {isLoggedIn && submissions.length > 5 && (
+                    <Link
+                      href="/submissions"
+                      className="text-sm text-blue-600 hover:underline flex items-center gap-1"
                     >
-                      Problems
-                    </a>{" "}
-                    and solve one.
+                      View all <ArrowRight className="w-3.5 h-3.5" />
+                    </Link>
+                  )}
+                </div>
+
+                {!isLoggedIn ? (
+                  <div className="bg-white dark:bg-zinc-800 rounded-xl p-6 text-center text-gray-500 dark:text-gray-400 shadow-[0_4px_20px_rgba(128,0,255,0.08)]">
+                    Log in to see your recent submissions.
+                  </div>
+                ) : recentTests.length === 0 ? (
+                  <div className="bg-white dark:bg-zinc-800 rounded-xl p-6 text-center shadow-[0_4px_20px_rgba(128,0,255,0.08)]">
+                    <p className="text-gray-500 dark:text-gray-400 mb-2">
+                      No submissions yet.
+                    </p>
+                    <Link
+                      href="/problems"
+                      className="text-blue-600 hover:underline"
+                    >
+                      Solve your first problem →
+                    </Link>
                   </div>
                 ) : (
-                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <div className="bg-white dark:bg-zinc-800 rounded-xl shadow-[0_4px_20px_rgba(128,0,255,0.08)] overflow-hidden">
                     {recentTests.map((s, i) => (
-                      <div
+                      <Link
                         key={s._id}
-                        className="bg-white dark:bg-zinc-800 rounded-xl p-4 shadow-[0_4px_20px_rgba(128,0,255,0.15)] transition duration-300 hover:scale-[1.02] hover:shadow-[0_6px_30px_rgba(128,0,255,0.3)]"
-                        data-aos="fade-up"
-                        data-aos-delay={i * 100}
+                        href={`/playground?id=${s.questionId}`}
+                        className={`flex items-center gap-3 p-4 hover:bg-gray-50 dark:hover:bg-zinc-700/50 transition ${
+                          i !== recentTests.length - 1
+                            ? "border-b border-gray-100 dark:border-zinc-700"
+                            : ""
+                        }`}
                       >
-                        <div className="flex items-start justify-between gap-2 mb-2">
-                          <h4 className="font-semibold truncate">
-                            {s.questionTitle || "Untitled"}
-                          </h4>
-                          {s.difficulty && (
-                            <span
-                              className={`text-xs px-2 py-0.5 rounded uppercase font-medium ${
-                                DIFFICULTY_BADGE[s.difficulty] ||
-                                "bg-gray-100 text-gray-700"
-                              }`}
-                            >
-                              {s.difficulty}
-                            </span>
-                          )}
-                        </div>
-                        <div className="flex items-center justify-between text-sm">
-                          <span
-                            className={`font-medium ${
-                              s.passed
-                                ? "text-green-600 dark:text-green-400"
-                                : "text-red-500 dark:text-red-400"
-                            }`}
-                          >
-                            {s.passed ? "✓ Passed" : "✗ Failed"}
-                          </span>
-                          <span className="text-purple-600 dark:text-purple-300 font-medium">
-                            {s.points || 0} pts
-                          </span>
-                        </div>
-                        {s.runtimeMs !== undefined && (
-                          <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                            {s.runtimeMs} ms · {s.language || "Unknown"}
-                          </p>
+                        {s.passed ? (
+                          <CheckCircle2 className="w-5 h-5 text-green-600 shrink-0" />
+                        ) : (
+                          <XCircle className="w-5 h-5 text-red-500 shrink-0" />
                         )}
-                      </div>
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <h4 className="font-medium truncate">
+                              {s.questionTitle || "Untitled"}
+                            </h4>
+                            {s.difficulty && (
+                              <span
+                                className={`text-[10px] px-1.5 py-0.5 rounded uppercase font-medium ${
+                                  DIFFICULTY_BADGE[s.difficulty] ||
+                                  "bg-gray-100 text-gray-700"
+                                }`}
+                              >
+                                {s.difficulty}
+                              </span>
+                            )}
+                          </div>
+                          <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                            {s.runtimeMs !== undefined && `${s.runtimeMs}ms · `}
+                            {s.language || "—"}
+                          </p>
+                        </div>
+                        <span className="text-sm text-purple-600 dark:text-purple-300 font-medium shrink-0">
+                          {s.points || 0} pts
+                        </span>
+                      </Link>
                     ))}
                   </div>
                 )}
               </section>
 
-              {/* Upcoming Quizzes (real data from Mongo) */}
+              {/* Upcoming Quizzes — only renders if there are quizzes,
+                  otherwise a small inline banner (no big empty box) */}
               <section data-aos="fade-up">
-                <h3 className="text-xl font-semibold mb-4">
+                <h3 className="text-xl font-semibold mb-3">
                   Upcoming Quizzes
                 </h3>
                 {quizzes.length === 0 ? (
-                  <div className="bg-white dark:bg-zinc-800 rounded-xl p-6 text-center text-gray-500 dark:text-gray-400 shadow-[0_4px_20px_rgba(128,0,255,0.15)]">
+                  <div className="bg-gray-50 dark:bg-zinc-900 border border-dashed border-gray-200 dark:border-zinc-700 rounded-xl p-4 flex items-center gap-3 text-sm text-gray-500 dark:text-gray-400">
+                    <CalendarDays className="w-5 h-5 shrink-0" />
                     No upcoming quizzes — check back soon.
                   </div>
                 ) : (
-                  <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
                     {quizzes.map((q, i) => (
                       <div
                         key={q._id}
-                        className="bg-white dark:bg-zinc-800 rounded-xl p-6 text-center shadow-[0_4px_20px_rgba(128,0,255,0.25)] transition duration-300 hover:scale-[1.03] hover:shadow-[0_6px_30px_rgba(128,0,255,0.45)]"
-                        data-aos="flip-up"
-                        data-aos-delay={i * 150}
+                        className="bg-white dark:bg-zinc-800 rounded-xl p-5 shadow-[0_4px_20px_rgba(128,0,255,0.12)] transition hover:scale-[1.02] hover:shadow-[0_6px_30px_rgba(128,0,255,0.25)]"
+                        data-aos="fade-up"
+                        data-aos-delay={i * 100}
                       >
-                        <h4 className="text-md font-medium">{q.title}</h4>
-                        <div className="text-4xl mt-4 mb-2">📅</div>
-                        <p className="mb-4 text-gray-600 dark:text-gray-400">
-                          {formatQuizDate(q.date)}
-                        </p>
+                        <div className="flex items-center gap-2 text-purple-600 mb-2">
+                          <CalendarDays className="w-4 h-4" />
+                          <span className="text-xs font-medium">
+                            {formatQuizDate(q.date)}
+                          </span>
+                        </div>
+                        <h4 className="font-semibold mb-3">{q.title}</h4>
                         {q.registrationLink ? (
                           <a
                             href={q.registrationLink}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="inline-block bg-purple-600 hover:bg-purple-700 text-white px-6 py-2 rounded-full transition"
+                            className="inline-block bg-purple-600 hover:bg-purple-700 text-white text-sm px-4 py-1.5 rounded-full transition"
                           >
                             Register
                           </a>
                         ) : (
-                          <button
-                            disabled
-                            className="bg-gray-300 dark:bg-zinc-600 text-gray-600 dark:text-gray-300 px-6 py-2 rounded-full cursor-not-allowed"
-                          >
+                          <span className="inline-block text-xs text-gray-400">
                             Details soon
-                          </button>
+                          </span>
                         )}
                       </div>
                     ))}
                   </div>
                 )}
               </section>
-
-              {/* Achievements — real stats per user */}
-              <section
-                className="grid grid-cols-1 sm:grid-cols-2 gap-6"
-                data-aos="fade-up"
-              >
-                <div className="bg-white dark:bg-zinc-800 rounded-xl p-6 shadow-[0_4px_20px_rgba(128,0,255,0.25)] transition duration-300 hover:scale-[1.02] hover:shadow-[0_6px_30px_rgba(128,0,255,0.4)]">
-                  <div className="flex items-center text-purple-600 font-bold text-xl mb-2">
-                    <FaClipboardList className="mr-2" /> {totalSubmissions}
-                  </div>
-                  <p className="text-gray-600 dark:text-gray-400">
-                    {isLoggedIn ? "Submissions" : "Log in to track activity"}
-                  </p>
-                </div>
-
-                <div className="bg-white dark:bg-zinc-800 rounded-xl p-6 shadow-[0_4px_20px_rgba(128,0,255,0.25)] transition duration-300 hover:scale-[1.02] hover:shadow-[0_6px_30px_rgba(128,0,255,0.4)]">
-                  <div className="flex items-center text-purple-600 font-bold text-xl mb-2">
-                    <BsFillBarChartFill className="mr-2" /> {accuracyPct}%
-                  </div>
-                  <p className="text-gray-600 dark:text-gray-400">
-                    {totalSubmissions > 0
-                      ? "Pass rate"
-                      : "Solve a problem to see your pass rate"}
-                  </p>
-                </div>
-              </section>
             </div>
 
-            {/* Right Column: Leaderboard */}
-            <div className="mt-2 lg:mt-16">
+            {/* Right column: Leaderboard — top-aligned, no more mt-16 hack */}
+            <aside className="space-y-6">
               <Lead />
-            </div>
+            </aside>
           </div>
 
-          {/* Topics Carousel */}
-          <section className="mt-20" data-aos="fade-up">
-            <div className="flex items-center justify-between mb-6">
+          {/* Topics with inline search + arrows */}
+          <section data-aos="fade-up">
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-5">
               <h3 className="text-2xl font-bold">Topics</h3>
-              <div className="flex items-center space-x-2 text-sm text-gray-500">
+              <div className="flex items-center gap-2 w-full sm:w-auto">
+                <div className="relative flex-1 sm:w-64">
+                  <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
+                  <input
+                    type="text"
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    placeholder="Search topics..."
+                    className="w-full pl-10 pr-3 py-2 rounded-full border border-gray-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500/30"
+                  />
+                </div>
                 <button
                   onClick={scrollLeft}
-                  className="p-2 rounded-full bg-gray-200 dark:bg-zinc-700 hover:bg-gray-300 dark:hover:bg-zinc-600 transition"
+                  className="p-2 rounded-full bg-white dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700 hover:bg-gray-100 dark:hover:bg-zinc-700 transition"
+                  aria-label="Scroll left"
                 >
-                  &lt;
+                  <ChevronLeft className="w-4 h-4" />
                 </button>
                 <button
                   onClick={scrollRight}
-                  className="p-2 rounded-full bg-gray-200 dark:bg-zinc-700 hover:bg-gray-300 dark:hover:bg-zinc-600 transition"
+                  className="p-2 rounded-full bg-white dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700 hover:bg-gray-100 dark:hover:bg-zinc-700 transition"
+                  aria-label="Scroll right"
                 >
-                  &gt;
+                  <ChevronRight className="w-4 h-4" />
                 </button>
               </div>
             </div>
 
-            <div className="relative">
+            {filteredTopics.length === 0 ? (
+              <p className="text-center text-gray-500 py-8">
+                {search ? `No topics match "${search}".` : "No topics yet."}
+              </p>
+            ) : (
               <div
                 ref={scrollRef}
-                className="flex space-x-8 overflow-x-auto scroll-smooth pb-2"
+                className="flex space-x-6 overflow-x-auto scroll-smooth pb-2"
               >
-                {Object.entries(grouped)
-                  .filter(([tag]) =>
-                    search.trim()
-                      ? tag.toLowerCase().includes(search.trim().toLowerCase())
-                      : true
-                  )
-                  .map(([tag, qs]) => (
-                    <TagCard key={tag} tag={tag} questions={qs} />
-                  ))}
+                {filteredTopics.map(([tag, qs]) => (
+                  <TagCard key={tag} tag={tag} questions={qs} />
+                ))}
               </div>
-            </div>
+            )}
           </section>
         </main>
         <Footer />
@@ -377,3 +389,25 @@ export default function ExplorePage() {
     </>
   );
 }
+
+const StatPill = ({
+  icon: Icon,
+  label,
+  value,
+}: {
+  icon: typeof TrendingUp;
+  label: string;
+  value: string | number;
+}) => (
+  <div className="bg-white dark:bg-zinc-800 rounded-xl p-4 shadow-[0_4px_20px_rgba(128,0,255,0.08)] flex items-center gap-3">
+    <div className="shrink-0 w-10 h-10 rounded-lg bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center text-white">
+      <Icon className="w-5 h-5" />
+    </div>
+    <div className="min-w-0">
+      <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
+        {label}
+      </p>
+      <p className="text-xl font-bold leading-tight">{value}</p>
+    </div>
+  </div>
+);

--- a/app/Profile/page.tsx
+++ b/app/Profile/page.tsx
@@ -11,7 +11,9 @@ import Navbar from "../components/Navbar";
 
 interface HistoryItem {
   title: string;
+  // Raw ISO string — HistorySection formats it as "2h ago" / "May 20".
   time: string;
+  passed?: boolean;
 }
 
 interface Submission {
@@ -63,7 +65,8 @@ export default function Page() {
           seen.add(key);
           historyArray.push({
             title: sub.questionTitle || "Untitled",
-            time: new Date(sub.submittedAt).toLocaleString(),
+            time: sub.submittedAt,
+            passed: sub.passed,
           });
         }
 

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -13,17 +13,28 @@ type User = {
   email: string;
   name?: string;
   username?: string;
-  status?: "Online" | "Idle" | "Busy" | "Offline";
+  status?: "Online" | "Idle" | "Offline";
+  lastSeen?: string;
 };
-
-const STATUS_OPTIONS: User["status"][] = ["Online", "Idle", "Busy", "Offline"];
 
 const statusClass: Record<NonNullable<User["status"]>, string> = {
   Online: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300",
   Idle: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-300",
-  Busy: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300",
   Offline: "bg-gray-200 text-gray-700 dark:bg-zinc-700 dark:text-gray-300",
 };
+
+function timeAgo(date?: string): string {
+  if (!date) return "—";
+  const diff = Date.now() - new Date(date).getTime();
+  if (Number.isNaN(diff) || diff < 0) return "—";
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+}
 
 export default function AdminUsersPage() {
   const { userData } = useSelector((state: RootState) => state.auth);
@@ -33,7 +44,6 @@ export default function AdminUsersPage() {
   const [users, setUsers] = useState<User[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [updating, setUpdating] = useState<string | null>(null);
 
   const fetchUsers = async () => {
     try {
@@ -45,25 +55,6 @@ export default function AdminUsersPage() {
       setError(e instanceof Error ? e.message : "Failed to load users");
     } finally {
       setLoading(false);
-    }
-  };
-
-  const updateStatus = async (userId: string, newStatus: User["status"]) => {
-    setUpdating(userId);
-    try {
-      const res = await fetch(`/api/dev/users/${userId}/status`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ status: newStatus }),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      setUsers((prev) =>
-        prev.map((u) => (u._id === userId ? { ...u, status: newStatus } : u))
-      );
-    } catch (e) {
-      alert(e instanceof Error ? e.message : "Update failed");
-    } finally {
-      setUpdating(null);
     }
   };
 
@@ -97,7 +88,8 @@ export default function AdminUsersPage() {
 
         <h1 className="text-3xl font-bold mb-1">Users</h1>
         <p className="text-gray-500 dark:text-gray-400 text-sm mb-6">
-          {users.length} registered
+          {users.length} registered · status derived from each user&apos;s
+          last heartbeat
         </p>
 
         {loading ? (
@@ -133,7 +125,7 @@ export default function AdminUsersPage() {
                     {user.email}
                   </p>
                 </div>
-                <div className="flex items-center gap-2 shrink-0">
+                <div className="flex items-center gap-3 shrink-0">
                   <span
                     className={`text-xs px-2 py-1 rounded-full ${
                       statusClass[user.status || "Offline"]
@@ -141,20 +133,12 @@ export default function AdminUsersPage() {
                   >
                     {user.status || "Offline"}
                   </span>
-                  <select
-                    value={user.status || "Offline"}
-                    onChange={(e) =>
-                      updateStatus(user._id, e.target.value as User["status"])
-                    }
-                    disabled={updating === user._id}
-                    className="text-xs px-2 py-1 border border-gray-300 dark:border-zinc-600 rounded bg-white dark:bg-zinc-700 disabled:opacity-50"
+                  <span
+                    className="text-xs text-gray-400 dark:text-gray-500 w-20 text-right"
+                    title="Last heartbeat received"
                   >
-                    {STATUS_OPTIONS.map((s) => (
-                      <option key={s} value={s}>
-                        {s}
-                      </option>
-                    ))}
-                  </select>
+                    {timeAgo(user.lastSeen)}
+                  </span>
                 </div>
               </div>
             ))}

--- a/app/api/dev/users/route.ts
+++ b/app/api/dev/users/route.ts
@@ -1,11 +1,23 @@
 // GET /api/dev/users
-// Lists users from MongoDB (dev/admin debugging endpoint).
-// Previously used the node-appwrite Users SDK; migrated to Mongoose so the
-// app no longer depends on Appwrite for this debug surface.
+// Returns the user list with `status` derived from each user's lastSeen
+// heartbeat — see lib/presence.ts. The stored `status` enum is legacy.
 
 import { NextResponse } from "next/server";
 import connectDB from "@/lib/mongodb";
 import UserModel from "@/models/Users";
+import { derivePresence } from "@/lib/presence";
+
+type LeanUser = {
+  _id: unknown;
+  email: string;
+  username?: string;
+  name?: string;
+  lastSeen?: Date;
+  activity?: string;
+  stats?: { totalSolved?: number };
+  createdAt?: Date;
+  updatedAt?: Date;
+};
 
 export async function GET() {
   try {
@@ -13,13 +25,18 @@ export async function GET() {
 
     const users = await UserModel.find({})
       .select(
-        "email username name status activity stats.totalSolved createdAt updatedAt"
+        "email username name lastSeen activity stats.totalSolved createdAt updatedAt"
       )
-      .sort({ createdAt: -1 })
+      .sort({ lastSeen: -1, createdAt: -1 })
       .limit(200)
-      .lean();
+      .lean<LeanUser[]>();
 
-    return NextResponse.json(users);
+    const decorated = users.map((u) => ({
+      ...u,
+      status: derivePresence(u.lastSeen),
+    }));
+
+    return NextResponse.json(decorated);
   } catch (error) {
     console.error("Failed to fetch users:", error);
     return NextResponse.json(

--- a/app/api/submit/route.ts
+++ b/app/api/submit/route.ts
@@ -8,8 +8,8 @@ export const runtime = "nodejs";
 
 const POINTS_BY_DIFFICULTY: Record<"easy" | "medium" | "hard", number> = {
   easy: 10,
-  medium: 25,
-  hard: 50,
+  medium: 20,
+  hard: 35,
 };
 
 function pointsFor(

--- a/app/api/user/heartbeat/route.ts
+++ b/app/api/user/heartbeat/route.ts
@@ -1,0 +1,42 @@
+// POST /api/user/heartbeat
+//   Body: { email }
+//   Bumps the user's lastSeen so derivePresence() reports them as Online.
+//   Called every ~30s by the client while the page is visible.
+
+import { NextRequest, NextResponse } from "next/server";
+import connectDB from "@/lib/mongodb";
+import Users from "@/models/Users";
+
+export const runtime = "nodejs";
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json().catch(() => ({}));
+    const email =
+      typeof body?.email === "string" ? body.email.trim().toLowerCase() : "";
+
+    if (!email) {
+      return NextResponse.json(
+        { success: false, error: "email is required" },
+        { status: 400 }
+      );
+    }
+
+    await connectDB();
+    // No-op if the user doesn't exist — we don't want a heartbeat to create
+    // records, and Mongo returns matchedCount=0 silently.
+    await Users.updateOne(
+      { email },
+      { $set: { lastSeen: new Date() } }
+    );
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to record heartbeat";
+    return NextResponse.json(
+      { success: false, error: message },
+      { status: 500 }
+    );
+  }
+}

--- a/app/community/page.tsx
+++ b/app/community/page.tsx
@@ -58,7 +58,7 @@ interface MemberSummary {
   email: string;
   name?: string;
   username?: string;
-  status?: "Online" | "Idle" | "Busy" | "Offline";
+  status?: "Online" | "Idle" | "Offline";
 }
 
 export default function CommunityPage() {
@@ -98,27 +98,36 @@ export default function CommunityPage() {
     fetchUser();
   }, []);
 
-  // Pull the member list for the right rail. Re-fetched once per session;
-  // status is stale-ish but good enough until we wire real presence.
+  // Pull the member list for the right rail. Server derives Online/Idle
+  // from each user's lastSeen heartbeat — re-fetch every 60s so the dots
+  // actually update as people come and go.
   useEffect(() => {
-    fetch("/api/dev/users")
-      .then((r) => r.json())
-      .then((data) => {
-        if (Array.isArray(data)) setMembers(data);
-      })
-      .catch(() => setMembers([]));
+    let cancelled = false;
+    const load = () => {
+      fetch("/api/dev/users")
+        .then((r) => r.json())
+        .then((data) => {
+          if (!cancelled && Array.isArray(data)) setMembers(data);
+        })
+        .catch(() => {
+          if (!cancelled) setMembers([]);
+        });
+    };
+    load();
+    const id = setInterval(load, 60 * 1000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
   }, []);
 
   const activeForum = forums.find((f) => f.key === selected) || forums[0];
 
-  // Group members by online status so Online appears first.
+  // Group members by derived presence so Online appears first.
   const groupedMembers = {
     online: members.filter((m) => m.status === "Online"),
     idle: members.filter((m) => m.status === "Idle"),
-    busy: members.filter((m) => m.status === "Busy"),
-    offline: members.filter(
-      (m) => !m.status || m.status === "Offline"
-    ),
+    offline: members.filter((m) => !m.status || m.status === "Offline"),
   };
 
   if (loading) {
@@ -263,11 +272,6 @@ export default function CommunityPage() {
                 label="Idle"
                 color="bg-yellow-500"
                 members={groupedMembers.idle}
-              />
-              <MemberGroup
-                label="Busy"
-                color="bg-red-500"
-                members={groupedMembers.busy}
               />
               <MemberGroup
                 label="Offline"

--- a/app/components/HistorySection.tsx
+++ b/app/components/HistorySection.tsx
@@ -1,21 +1,58 @@
 "use client";
 
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  CheckCircle2,
+  XCircle,
+  Circle,
+} from "lucide-react";
 import { useState } from "react";
 
 interface HistoryItem {
   title: string;
+  // ISO timestamp string — formatted relatively below.
   time: string;
+  passed?: boolean;
 }
 
 interface Props {
   historyData: HistoryItem[];
 }
 
+// Compact relative formatter. Falls back to a short date for anything older
+// than a week so rows stay scannable even with hundreds of submissions.
+function formatRelative(iso: string): string {
+  const ts = new Date(iso).getTime();
+  if (Number.isNaN(ts)) return iso;
+  const diff = Date.now() - ts;
+  if (diff < 0) return "just now";
+
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+
+  const days = Math.floor(hrs / 24);
+  if (days === 1) return "yesterday";
+  if (days < 7) return `${days}d ago`;
+
+  return new Date(ts).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year:
+      new Date(ts).getFullYear() === new Date().getFullYear()
+        ? undefined
+        : "numeric",
+  });
+}
+
 const HistorySection = ({ historyData }: Props) => {
   const [currentPage, setCurrentPage] = useState(1);
   const perPage = 10;
-  const totalPages = Math.ceil(historyData.length / perPage);
+  const totalPages = Math.max(1, Math.ceil(historyData.length / perPage));
   const startIndex = (currentPage - 1) * perPage;
   const currentItems = historyData.slice(startIndex, startIndex + perPage);
 
@@ -23,29 +60,31 @@ const HistorySection = ({ historyData }: Props) => {
     <section className="bg-white dark:bg-zinc-800 rounded-2xl shadow-lg p-4 lg:p-6 flex-1 flex flex-col">
       <div className="flex justify-between items-center mb-4">
         <h3 className="text-lg lg:text-xl font-semibold">Recent Activity</h3>
-        <div className="flex items-center gap-2 lg:gap-3">
-          <span className="text-xs lg:text-sm text-gray-500 dark:text-gray-400">
-            Page {currentPage} of {totalPages}
-          </span>
-          <div className="flex gap-1">
-            <button
-              onClick={() => setCurrentPage(Math.max(1, currentPage - 1))}
-              disabled={currentPage === 1}
-              className="p-1 rounded-md hover:bg-gray-100 dark:hover:bg-zinc-700 disabled:opacity-50"
-            >
-              <ChevronLeft size={14} />
-            </button>
-            <button
-              onClick={() =>
-                setCurrentPage(Math.min(totalPages, currentPage + 1))
-              }
-              disabled={currentPage === totalPages}
-              className="p-1 rounded-md hover:bg-gray-100 dark:hover:bg-zinc-700 disabled:opacity-50"
-            >
-              <ChevronRight size={14} />
-            </button>
+        {historyData.length > perPage && (
+          <div className="flex items-center gap-2 lg:gap-3">
+            <span className="text-xs lg:text-sm text-gray-500 dark:text-gray-400">
+              Page {currentPage} of {totalPages}
+            </span>
+            <div className="flex gap-1">
+              <button
+                onClick={() => setCurrentPage(Math.max(1, currentPage - 1))}
+                disabled={currentPage === 1}
+                className="p-1 rounded-md hover:bg-gray-100 dark:hover:bg-zinc-700 disabled:opacity-50"
+              >
+                <ChevronLeft size={14} />
+              </button>
+              <button
+                onClick={() =>
+                  setCurrentPage(Math.min(totalPages, currentPage + 1))
+                }
+                disabled={currentPage === totalPages}
+                className="p-1 rounded-md hover:bg-gray-100 dark:hover:bg-zinc-700 disabled:opacity-50"
+              >
+                <ChevronRight size={14} />
+              </button>
+            </div>
           </div>
-        </div>
+        )}
       </div>
       <div className="divide-y divide-gray-200 dark:divide-zinc-700 flex-1 overflow-auto">
         {currentItems.length === 0 ? (
@@ -56,13 +95,32 @@ const HistorySection = ({ historyData }: Props) => {
           currentItems.map((item, index) => (
             <div
               key={index}
-              className="flex justify-between items-center px-2 py-3 hover:bg-gray-100 dark:hover:bg-zinc-700 transition rounded-md"
+              className="flex justify-between items-center gap-3 px-2 py-3 hover:bg-gray-100 dark:hover:bg-zinc-700 transition rounded-md"
             >
-              <p className="truncate max-w-[70%] lg:max-w-[80%] text-sm">
-                {item.title}
-              </p>
-              <span className="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
-                {item.time}
+              <div className="flex items-center gap-2 min-w-0 flex-1">
+                {item.passed === true ? (
+                  <CheckCircle2
+                    className="w-4 h-4 text-green-600 shrink-0"
+                    aria-label="Passed"
+                  />
+                ) : item.passed === false ? (
+                  <XCircle
+                    className="w-4 h-4 text-red-500 shrink-0"
+                    aria-label="Failed"
+                  />
+                ) : (
+                  <Circle
+                    className="w-4 h-4 text-gray-300 shrink-0"
+                    aria-label="Unknown"
+                  />
+                )}
+                <p className="truncate text-sm">{item.title}</p>
+              </div>
+              <span
+                className="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap shrink-0"
+                title={new Date(item.time).toLocaleString()}
+              >
+                {formatRelative(item.time)}
               </span>
             </div>
           ))

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -14,6 +14,7 @@ import { getAuth, signOut } from "firebase/auth";
 import { app } from "@/lib/firebase";
 import { CgProfile } from "react-icons/cg";
 import { isAdminEmail } from "@/lib/auth";
+import { useHeartbeat } from "@/lib/useHeartbeat";
 
 // Single source of truth for navbar labels → URLs.
 // Routes keep their existing casing to avoid breaking external links/bookmarks.
@@ -42,6 +43,10 @@ const Navbar = () => {
 
   const authState = useSelector((state: RootState) => state.auth);
   const isLoggedIn = authState.status;
+
+  // Presence heartbeat — runs everywhere the Navbar is mounted, which is
+  // every authenticated page.
+  useHeartbeat(isLoggedIn ? authState.userData?.email : null);
 
   useEffect(() => {
     const checkUser = async () => {
@@ -83,7 +88,7 @@ const Navbar = () => {
   const handleVibeClick = () => {
     setMenuOpen(false);
     setShowProfileMenu(false);
-    router.push("playground?id=6884bb87f1b587e466becd87");
+    router.push("/problems");
   };
 
   const handleMobileNavClick = (path: string) => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,64 +11,54 @@ import { motion } from "framer-motion";
 import { useSelector } from "react-redux";
 import { RootState } from "./store/store";
 
-// Helper for random between min and max
-const rand = (min: number, max: number) =>
-  Math.floor(Math.random() * (max - min + 1)) + min;
+// Static ring props — values are derived from index, no Math.random() so
+// server and client render identical HTML (was causing a hydration flash).
+const MOBILE_RING_POSITIONS = [
+  { top: 30, left: 40 },
+  { bottom: 30, right: 30 },
+  { top: 50, right: 20 },
+  { bottom: 60, left: 30 },
+  { bottom: 60, right: 30 },
+];
 
-// Generate random properties for 5 rings on mobile
-const genMobileRingProps = () =>
-  Array(5)
-    .fill(0)
-    .map(() => {
-      const positions = [
-        { style: { top: rand(10, 60), left: rand(10, 70) } },
-        { style: { bottom: rand(10, 60), right: rand(10, 70) } },
-        { style: { top: rand(10, 70), right: rand(10, 60) } },
-        { style: { bottom: rand(10, 70), left: rand(10, 60) } },
-        { style: { bottom: rand(30, 80), right: rand(10, 50) } },
-      ];
-      const pos = positions[rand(0, positions.length - 1)].style;
-      const animTime = rand(2800, 4200);
-      const animX = rand(8, 32) * (Math.random() > 0.5 ? 1 : -1);
-      const animY = rand(8, 32) * (Math.random() > 0.5 ? 1 : -1);
-      return {
-        style: {
-          position: "absolute",
-          ...pos,
-          opacity: Math.random() > 0.5 ? 0.4 : 0.3,
-          animation: `floatRingMobile ${animTime}ms ease-in-out infinite alternate`,
-          "--ring-anim-x": `${animX}px`,
-          "--ring-anim-y": `${animY}px`,
-        } as unknown as React.CSSProperties,
-      };
-    });
+const DESKTOP_RING_POSITIONS = [
+  { top: 96, left: 80 },
+  { bottom: 16, right: 40 },
+  { top: 40, right: 64 },
+  { bottom: 64, left: 40 },
+  { bottom: 112, right: 112 },
+];
 
-// Generate random properties for desktop rings (fixed positions + animation)
-const genDesktopRingProps = () => {
-  const positions = [
-    { top: 96, left: 80 }, // top-24 left-20 (24*4=96, 20*4=80 px)
-    { bottom: 16, right: 40 }, // bottom-4 right-10
-    { top: 40, right: 64 }, // top-10 right-16
-    { bottom: 64, left: 40 }, // bottom-16 left-10
-    { bottom: 112, right: 112 }, // bottom-28 right-28
-  ];
-
-  return positions.map((pos) => {
-    const animTime = rand(2800, 4200);
-    const animX = rand(8, 32) * (Math.random() > 0.5 ? 1 : -1);
-    const animY = rand(8, 32) * (Math.random() > 0.5 ? 1 : -1);
-    return {
-      style: {
-        position: "absolute",
-        ...pos,
-        opacity: 0.4,
-        animation: `floatRingDesktop ${animTime}ms ease-in-out infinite alternate`,
-        "--ring-anim-x": `${animX}px`,
-        "--ring-anim-y": `${animY}px`,
-      } as unknown as React.CSSProperties,
-    };
-  });
+type RingPos = {
+  top?: number;
+  left?: number;
+  bottom?: number;
+  right?: number;
 };
+
+const ringStyle = (
+  pos: RingPos,
+  i: number,
+  keyframe: string
+): React.CSSProperties =>
+  ({
+    position: "absolute",
+    ...pos,
+    opacity: i % 2 === 0 ? 0.4 : 0.3,
+    // Stagger animation timings so they don't move in lockstep, but
+    // deterministically — same value every render.
+    animation: `${keyframe} ${3000 + i * 250}ms ease-in-out infinite alternate`,
+    "--ring-anim-x": `${(i % 2 === 0 ? 1 : -1) * (10 + i * 4)}px`,
+    "--ring-anim-y": `${(i % 3 === 0 ? 1 : -1) * (12 + i * 3)}px`,
+  } as unknown as React.CSSProperties);
+
+const mobileRingProps = MOBILE_RING_POSITIONS.map((pos, i) => ({
+  style: ringStyle(pos, i, "floatRingMobile"),
+}));
+
+const desktopRingProps = DESKTOP_RING_POSITIONS.map((pos, i) => ({
+  style: ringStyle(pos, i, "floatRingDesktop"),
+}));
 
 // Define the CSS animation keyframes
 const mobileRingsCSS = `
@@ -93,14 +83,6 @@ export default function Home() {
   const [loggedIn, setLoggedIn] = useState(false);
   const value = useSelector((state: RootState) => state.auth.status);
 
-  // For random ring positions on each mount
-  const [mobileRingProps, setMobileRingProps] = useState(() =>
-    genMobileRingProps()
-  );
-  const [desktopRingProps, setDesktopRingProps] = useState(() =>
-    genDesktopRingProps()
-  );
-
   useEffect(() => {
     AOS.init({
       duration: 1000,
@@ -117,12 +99,6 @@ export default function Home() {
     };
     checkUser();
   }, [value]);
-
-  // On remounts, update rings
-  useEffect(() => {
-    setMobileRingProps(genMobileRingProps());
-    setDesktopRingProps(genDesktopRingProps());
-  }, []);
 
   return (
     <>
@@ -190,7 +166,7 @@ export default function Home() {
                   skills, expand your knowledge and prepare for technical
                   interviews.
                 </p>
-                <Link href="playground?id=6884bb87f1b587e466becd87" passHref>
+                <Link href="/problems" passHref>
                   <motion.button
                     whileHover={{ scale: 1.05 }}
                     whileTap={{ scale: 0.95 }}

--- a/app/playground/page.tsx
+++ b/app/playground/page.tsx
@@ -14,8 +14,6 @@ import {
 } from "firebase/firestore";
 import { db } from "@/lib/firebase";
 import Navbar from "../components/Navbar";
-import SoundBoard from "../components/SoundBoard";
-import Lead from "../components/Lead";
 import { useSelector } from "react-redux";
 import type { RootState } from "../store/store";
 import SuccessModal from "../components/SuccessModal";
@@ -334,92 +332,100 @@ function PlaygroundContent() {
   };
 
   return (
-    <div className="min-h-screen flex flex-col dark:bg-[#020612] text-gray-900 dark:text-white">
+    <div className="h-screen flex flex-col dark:bg-[#020612] text-gray-900 dark:text-white">
       <Navbar />
-      <div className="flex flex-1 p-3 gap-4 overflow-hidden flex-col md:flex-row">
-        {/* Left Panel */}
-        <div className="w-full md:w-1/4 flex flex-col gap-4 overflow-auto">
-          {/* Question Section */}
-          <section className="bg-white dark:bg-gray-800 rounded-2xl p-4 shadow dark:shadow-lg h-[200px] md:h-[30%] flex flex-col">
-            <h2 className="text-xl font-semibold mb-2">🧠 Question</h2>
+      <div className="flex flex-1 p-3 gap-3 overflow-hidden flex-col lg:flex-row min-h-0">
+        {/* Left — Question + Testcases + Notes (stacked, scrollable) */}
+        <div className="w-full lg:w-2/5 flex flex-col gap-3 overflow-hidden min-h-0">
+          <section className="bg-white dark:bg-zinc-800 rounded-2xl p-5 shadow-[0_4px_20px_rgba(128,0,255,0.08)] flex flex-col min-h-0 flex-[2]">
+            <div className="flex items-center justify-between mb-3">
+              <h2 className="text-lg font-semibold">🧠 Question</h2>
+              {question?.difficulty && (
+                <span
+                  className={`text-[10px] px-2 py-0.5 rounded uppercase font-medium ${
+                    question.difficulty === "easy"
+                      ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300"
+                      : question.difficulty === "medium"
+                      ? "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-300"
+                      : "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300"
+                  }`}
+                >
+                  {question.difficulty}
+                </span>
+              )}
+            </div>
             {loading ? (
               <p className="text-sm text-gray-500">Loading...</p>
             ) : error ? (
               <p className="text-sm text-red-500">Error: {error}</p>
             ) : question ? (
               <>
-                <h3 className="font-bold mb-2">{question.title}</h3>
-                <div className="text-sm overflow-auto flex-1 prose dark:prose-invert">
+                <h3 className="font-bold text-base mb-2">{question.title}</h3>
+                <div className="text-sm overflow-auto flex-1 prose dark:prose-invert max-w-none">
                   <ReactMarkdown>{question.description}</ReactMarkdown>
                 </div>
               </>
             ) : !questionId ? (
-              <>
-                <h3 className="font-semibold mb-1">Free Coding Playground</h3>
-                <p className="text-sm text-gray-500 dark:text-gray-400">
-                  You&apos;re in standalone mode. Pick a question from{" "}
+              <div className="text-sm text-gray-500 dark:text-gray-400">
+                <h3 className="font-semibold mb-1 text-gray-700 dark:text-gray-200">
+                  Free Coding Playground
+                </h3>
+                <p>
+                  Pick a problem from{" "}
                   <a
                     href="/problems"
                     className="text-blue-500 hover:underline"
                   >
                     Problems
                   </a>{" "}
-                  to attempt one, or just experiment with the editor on the
-                  right.
+                  to attempt one, or just experiment with the editor.
                 </p>
-              </>
+              </div>
             ) : (
               <p className="text-sm text-gray-500">No question found</p>
             )}
           </section>
 
-          {/* Testcases Section */}
-          <section className="bg-white dark:bg-gray-800 rounded-2xl p-4 shadow dark:shadow-lg h-[200px] md:h-[30%] flex flex-col">
-            <h2 className="text-lg font-semibold mb-2">🧪 Testcases</h2>
+          <section className="bg-white dark:bg-zinc-800 rounded-2xl p-5 shadow-[0_4px_20px_rgba(128,0,255,0.08)] flex flex-col min-h-0 flex-1">
+            <h2 className="text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-2">
+              🧪 Testcases
+            </h2>
             {loading ? (
               <p className="text-sm text-gray-500">Loading...</p>
             ) : question?.testcases ? (
-              <pre className="text-sm whitespace-pre-wrap overflow-auto flex-1">
+              <pre className="text-sm whitespace-pre-wrap overflow-auto flex-1 font-mono bg-gray-50 dark:bg-zinc-900 rounded p-2">
                 {question.testcases}
               </pre>
             ) : !questionId ? (
               <p className="text-sm text-gray-500">
-                No challenge selected — testcases will appear here.
+                No challenge selected.
               </p>
             ) : (
-              <p className="text-sm text-gray-500">No testcases available</p>
+              <p className="text-sm text-gray-500">No testcases available.</p>
             )}
           </section>
 
-          {/* Answer Markdown Section */}
-          <section className="bg-white dark:bg-gray-800 rounded-2xl p-4 shadow dark:shadow-lg h-[300px] md:h-[600px] flex flex-col">
-            <h2 className="text-lg font-semibold mb-2">
-              📝 Your Answer (Markdown)
+          <section className="bg-white dark:bg-zinc-800 rounded-2xl p-5 shadow-[0_4px_20px_rgba(128,0,255,0.08)] flex flex-col min-h-0 flex-1">
+            <h2 className="text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-2">
+              📝 Notes
             </h2>
             <textarea
               value={answerInput}
               onChange={(e) => setAnswerInput(e.target.value)}
-              placeholder="Write your solution in Markdown here..."
-              className="flex-1 resize-none p-3 border border-gray-300 dark:border-gray-700 rounded-md bg-gray-50 dark:bg-[#2a2a2f] text-sm text-gray-900 dark:text-gray-100 outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="Quick notes on your approach (required for submit)..."
+              className="flex-1 min-h-[60px] resize-none p-2 border border-gray-200 dark:border-zinc-700 rounded bg-gray-50 dark:bg-zinc-900 text-sm outline-none focus:ring-2 focus:ring-purple-500/30"
             />
-            <h3 className="mt-4 mb-2 font-semibold text-sm">Live Preview</h3>
-            <div className="flex-1 overflow-auto prose dark:prose-invert border border-gray-200 dark:border-gray-700 rounded p-3 bg-white dark:bg-gray-900 text-sm">
-              <ReactMarkdown>
-                {answerInput || "_Nothing to preview_"}
-              </ReactMarkdown>
-            </div>
           </section>
         </div>
 
-        {/* Center Panel */}
-        <div className="w-full md:w-2/4 flex flex-col gap-4 overflow-hidden">
-          {/* Compiler Section */}
-          <section className="bg-white dark:bg-gray-800 rounded-2xl p-4 shadow dark:shadow-lg h-[200px] md:h-[600px] overflow-hidden flex flex-col gap-y-2">
-            <div className="flex justify-between items-center mb-2">
+        {/* Right — Compiler (top) + Result (bottom) */}
+        <div className="w-full lg:w-3/5 flex flex-col gap-3 overflow-hidden min-h-0">
+          <section className="bg-white dark:bg-zinc-800 rounded-2xl p-5 shadow-[0_4px_20px_rgba(128,0,255,0.08)] flex flex-col min-h-0 flex-[2]">
+            <div className="flex justify-between items-center mb-3">
               <h2 className="text-lg font-semibold">💻 Compiler</h2>
-              <div className="flex items-center gap-3">
+              <div className="flex items-center gap-2">
                 <select
-                  className="dark:bg-gray-800 px-2 py-1 rounded"
+                  className="text-sm bg-gray-50 dark:bg-zinc-900 border border-gray-200 dark:border-zinc-700 px-2 py-1 rounded"
                   value={language}
                   onChange={(e) =>
                     handleLanguageChange(e.target.value as Language)
@@ -434,7 +440,7 @@ function PlaygroundContent() {
                 </select>
                 <button
                   onClick={handleResetCode}
-                  className="px-3 py-1 text-sm bg-gray-200 dark:bg-gray-600 hover:bg-gray-300 dark:hover:bg-gray-500 rounded-md"
+                  className="px-3 py-1 text-sm bg-gray-100 dark:bg-zinc-700 hover:bg-gray-200 dark:hover:bg-zinc-600 rounded"
                   disabled={isRunning}
                 >
                   Reset
@@ -442,7 +448,7 @@ function PlaygroundContent() {
               </div>
             </div>
 
-            <div className="flex-1">
+            <div className="flex-1 min-h-0 rounded overflow-hidden border border-gray-200 dark:border-zinc-700">
               <MonacoEditor
                 height="100%"
                 language={languageMap[language].monacoLang}
@@ -458,110 +464,97 @@ function PlaygroundContent() {
               />
             </div>
 
-            <div className="mt-2">
+            <div className="mt-3 flex items-center justify-end gap-2">
+              {isCorrect === true && (
+                <button
+                  onClick={handleSubmit}
+                  disabled={isSubmitting}
+                  className="px-4 py-2 rounded-lg text-sm font-medium text-white bg-gradient-to-r from-green-500 to-emerald-600 hover:opacity-90 disabled:opacity-50"
+                >
+                  {isSubmitting ? "Submitting..." : "Submit Answer"}
+                </button>
+              )}
               <button
-                className={`bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 disabled:bg-gray-500`}
+                className="px-4 py-2 rounded-lg text-sm font-medium bg-blue-600 hover:bg-blue-700 text-white disabled:opacity-50"
                 onClick={handleRun}
                 disabled={isRunning}
               >
-                {isRunning ? "⏳ Running..." : "Run Code"}
+                {isRunning ? "Running…" : "Run Code"}
               </button>
             </div>
           </section>
 
-          {/* Result Section */}
-          <section className="bg-white dark:bg-gray-800 rounded-2xl p-4 shadow dark:shadow-lg max-h-60 overflow-auto flex flex-col gap-y-2">
-            <div className="flex justify-between items-center">
-              <h2 className="text-lg font-semibold">📄 Result</h2>
+          <section className="bg-white dark:bg-zinc-800 rounded-2xl p-5 shadow-[0_4px_20px_rgba(128,0,255,0.08)] flex flex-col min-h-0 flex-1 overflow-hidden">
+            <div className="flex justify-between items-center mb-2">
+              <h2 className="text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                📄 Result
+              </h2>
               {output && (
                 <button
                   onClick={handleClearOutput}
-                  className="px-3 py-1 text-sm bg-gray-200 dark:bg-gray-600 hover:bg-gray-300 dark:hover:bg-gray-500 rounded-md"
+                  className="text-xs px-2 py-0.5 bg-gray-100 dark:bg-zinc-700 hover:bg-gray-200 dark:hover:bg-zinc-600 rounded"
                 >
                   Clear
                 </button>
               )}
             </div>
-            <pre className="text-sm whitespace-pre-wrap">
-              {output || "Output will appear here after running your code..."}
-            </pre>
 
-            {isCorrect === true && (
-              <>
-                <p className="text-green-600 font-semibold">
-                  🎉 Correct Output! You can submit your answer.
+            <div className="flex-1 overflow-auto min-h-0 space-y-2">
+              <pre className="text-sm whitespace-pre-wrap font-mono bg-gray-50 dark:bg-zinc-900 rounded p-3 min-h-[40px]">
+                {output || (
+                  <span className="text-gray-400">
+                    Output will appear here after running your code.
+                  </span>
+                )}
+              </pre>
+
+              {isCorrect === true && (
+                <p className="text-green-600 dark:text-green-400 text-sm font-medium">
+                  🎉 Correct! Hit Submit Answer above.
                 </p>
-                <button
-                  onClick={handleSubmit}
-                  disabled={isSubmitting}
-                  className={`mt-2 px-4 py-2 rounded text-white ${
-                    isSubmitting
-                      ? "bg-gray-500 cursor-not-allowed"
-                      : "bg-green-600 hover:bg-green-700"
-                  }`}
-                >
-                  {isSubmitting ? "Submitting..." : "Submit Answer"}
-                </button>
-              </>
-            )}
+              )}
 
-            {isCorrect === false && diffLines.length > 0 && (
-              <>
-                <p className="text-red-500 font-semibold mb-1">
-                  🚫 Output does not match expected answer. See Diff below:
+              {isCorrect === false && diffLines.length > 0 && (
+                <>
+                  <p className="text-red-500 text-sm font-medium">
+                    🚫 Output doesn&apos;t match expected — diff below:
+                  </p>
+                  <div className="rounded border border-gray-200 dark:border-zinc-700 p-2 overflow-x-auto text-xs font-mono bg-gray-50 dark:bg-zinc-900">
+                    {diffLines.map((line, idx) =>
+                      line.type === "same" ? (
+                        <div key={idx} className="text-gray-500">
+                          &nbsp; {line.value}
+                        </div>
+                      ) : line.type === "remove" ? (
+                        <div
+                          key={idx}
+                          className="bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300"
+                        >
+                          - {line.value}
+                        </div>
+                      ) : (
+                        <div
+                          key={idx}
+                          className="bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300"
+                        >
+                          + {line.value}
+                        </div>
+                      )
+                    )}
+                  </div>
+                </>
+              )}
+
+              {isCorrect === false && !diffLines.length && (
+                <p className="text-red-500 text-sm font-medium">
+                  🚫 Output doesn&apos;t match expected answer.
                 </p>
-                <div
-                  style={{
-                    background:
-                      "repeating-linear-gradient(90deg,#222 0 5%,#202026 5% 10%)",
-                  }}
-                  className="rounded border border-gray-300 dark:border-gray-700 p-2 overflow-x-auto text-xs font-mono"
-                >
-                  {diffLines.map((line, idx) =>
-                    line.type === "same" ? (
-                      <div key={idx} style={{ color: "#999" }}>
-                        &nbsp; {line.value}
-                      </div>
-                    ) : line.type === "remove" ? (
-                      <div
-                        key={idx}
-                        style={{ background: "#ffeaea", color: "#d44" }}
-                      >
-                        - {line.value}
-                      </div>
-                    ) : (
-                      <div
-                        key={idx}
-                        style={{ background: "#eaffea", color: "#287c34" }}
-                      >
-                        + {line.value}
-                      </div>
-                    )
-                  )}
-                </div>
-              </>
-            )}
-
-            {isCorrect === false && !diffLines.length && (
-              <p className="text-red-500 font-semibold">
-                🚫 Output does not match expected answer.
-              </p>
-            )}
-          </section>
-        </div>
-
-        {/* Right Panel */}
-        <div className="w-full md:w-1/4 flex flex-col gap-4 overflow-auto">
-          <section className="bg-white dark:bg-gray-800 rounded-2xl p-4 shadow dark:shadow-lg h-[200px] md:h-[45%]">
-            <SoundBoard />
-          </section>
-
-          <section className="bg-white dark:bg-gray-800 rounded-2xl p-4 shadow dark:shadow-lg flex-1 overflow-auto">
-            <Lead />
+              )}
+            </div>
           </section>
         </div>
       </div>
-      {/* ---- MODAL BELOW ---- */}
+
       {showSuccessModal && (
         <SuccessModal onClose={() => setShowSuccessModal(false)} />
       )}

--- a/app/problems/page.tsx
+++ b/app/problems/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { useSelector } from "react-redux";
 import { doc, getDoc } from "firebase/firestore";
 import { db } from "@/lib/firebase";
+import { Search, Tag, SlidersHorizontal, ChevronDown } from "lucide-react";
 import type { RootState } from "../store/store";
 import Navbar from "../components/Navbar";
 
@@ -217,31 +218,35 @@ export default function ProblemsPage() {
 
           {!loading && !error && questions.length > 0 && (
             <div className="mb-8 space-y-4">
-              <div className="flex flex-col sm:flex-row gap-4">
+              <div className="bg-white dark:bg-zinc-800 rounded-2xl shadow-[0_4px_20px_rgba(128,0,255,0.08)] p-4 flex flex-col sm:flex-row gap-3">
                 {/* Search Input */}
-                <div className="flex-1">
+                <div className="relative flex-1">
+                  <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
                   <input
                     type="text"
-                    placeholder="Search questions by title, description, or tags..."
+                    placeholder="Search by title, description, or tags..."
                     value={searchTerm}
                     onChange={(e) => setSearchTerm(e.target.value)}
-                    className="w-full p-3 rounded-lg bg-white dark:bg-[#1a1a1d] border border-gray-300 dark:border-gray-600 focus:ring-2 focus:ring-blue-500 focus:border-transparent outline-none transition-colors"
+                    className="w-full pl-10 pr-3 py-2.5 rounded-xl bg-gray-50 dark:bg-zinc-900 border border-transparent focus:border-purple-500 focus:ring-2 focus:ring-purple-500/30 outline-none transition text-sm"
                   />
                 </div>
 
                 {/* Tag Filter */}
-                <div className="relative sm:w-64">
+                <div className="relative sm:w-56">
                   <button
                     type="button"
                     onClick={() => setShowTagDropdown((v) => !v)}
-                    className={`w-full text-left p-3 rounded-lg border ${
+                    className={`w-full flex items-center gap-2 px-3 py-2.5 rounded-xl border text-sm font-medium transition ${
                       selectedTag
-                        ? "bg-blue-100 dark:bg-blue-800 text-blue-800 dark:text-blue-200"
-                        : "bg-white dark:bg-[#1a1a1d] text-gray-900 dark:text-gray-200"
-                    } border-gray-300 dark:border-gray-600 focus:ring-2 focus:ring-blue-500 outline-none`}
+                        ? "bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-200 border-purple-300 dark:border-purple-700"
+                        : "bg-gray-50 dark:bg-zinc-900 text-gray-700 dark:text-gray-200 border-transparent hover:border-gray-300 dark:hover:border-zinc-700"
+                    }`}
                   >
-                    {selectedTag ? `Tag: ${selectedTag}` : "Filter by tag..."}
-                    <span className="float-right ml-2">&#x25BC;</span>
+                    <Tag className="w-4 h-4 shrink-0" />
+                    <span className="flex-1 text-left truncate">
+                      {selectedTag ? selectedTag : "Filter by tag"}
+                    </span>
+                    <ChevronDown className="w-4 h-4 shrink-0 opacity-70" />
                   </button>
 
                   {showTagDropdown && (
@@ -301,17 +306,19 @@ export default function ProblemsPage() {
                 </div>
 
                 {/* Difficulty Filter */}
-                <div className="relative sm:w-44">
+                <div className="relative sm:w-48">
+                  <SlidersHorizontal className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
                   <select
                     value={selectedDifficulty}
                     onChange={(e) => setSelectedDifficulty(e.target.value)}
-                    className="w-full p-3 rounded-lg bg-white dark:bg-[#1a1a1d] border border-gray-300 dark:border-gray-600 text-gray-900 dark:text-gray-200 focus:ring-2 focus:ring-blue-500 outline-none"
+                    className="w-full pl-10 pr-8 py-2.5 rounded-xl bg-gray-50 dark:bg-zinc-900 border border-transparent hover:border-gray-300 dark:hover:border-zinc-700 text-gray-700 dark:text-gray-200 focus:border-purple-500 focus:ring-2 focus:ring-purple-500/30 outline-none transition text-sm font-medium appearance-none cursor-pointer"
                   >
-                    <option value="">Filter by difficulty...</option>
+                    <option value="">All difficulties</option>
                     <option value="easy">Easy</option>
                     <option value="medium">Medium</option>
                     <option value="hard">Hard</option>
                   </select>
+                  <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
                 </div>
               </div>
 

--- a/lib/presence.ts
+++ b/lib/presence.ts
@@ -1,0 +1,18 @@
+// Derive presence from a user's lastSeen timestamp.
+// Single source of truth — both API and any client consumer should use this.
+
+export type PresenceStatus = "Online" | "Idle" | "Offline";
+
+const ONLINE_WINDOW_MS = 2 * 60 * 1000; // 2 min
+const IDLE_WINDOW_MS = 10 * 60 * 1000; // 10 min
+
+export function derivePresence(lastSeen?: Date | string | null): PresenceStatus {
+  if (!lastSeen) return "Offline";
+  const ts =
+    lastSeen instanceof Date ? lastSeen.getTime() : new Date(lastSeen).getTime();
+  if (Number.isNaN(ts)) return "Offline";
+  const age = Date.now() - ts;
+  if (age < ONLINE_WINDOW_MS) return "Online";
+  if (age < IDLE_WINDOW_MS) return "Idle";
+  return "Offline";
+}

--- a/lib/useHeartbeat.ts
+++ b/lib/useHeartbeat.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect } from "react";
+
+const HEARTBEAT_INTERVAL_MS = 30 * 1000; // 30 s
+
+// Pings /api/user/heartbeat while the tab is visible so server-side
+// derivePresence() can report this user as Online. Pauses on hidden tabs
+// so a background tab doesn't pretend the user is here.
+export function useHeartbeat(email: string | null | undefined) {
+  useEffect(() => {
+    if (!email) return;
+    const target = email.trim().toLowerCase();
+    if (!target) return;
+
+    let cancelled = false;
+
+    const ping = () => {
+      if (cancelled) return;
+      if (typeof document !== "undefined" && document.visibilityState !== "visible")
+        return;
+      // Use keepalive so the request survives a tab-close race.
+      fetch("/api/user/heartbeat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: target }),
+        keepalive: true,
+      }).catch(() => {
+        // Network blip — next interval will retry.
+      });
+    };
+
+    // Immediate ping on mount so the user appears Online without waiting
+    // a full interval.
+    ping();
+    const id = setInterval(ping, HEARTBEAT_INTERVAL_MS);
+
+    // Ping again when the tab regains focus — covers the "came back after
+    // 20 min" case without waiting for the next scheduled tick.
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") ping();
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [email]);
+}

--- a/models/Users.ts
+++ b/models/Users.ts
@@ -38,13 +38,18 @@ const UserSchema = new mongoose.Schema(
     password: { type: String },
     name: { type: String, default: "" },
 
-    // Status & activity
+    // Status & activity. `status` is legacy (manual admin override, kept
+    // for backwards-compat). Presence is now derived from `lastSeen` —
+    // see lib/presence.ts / /api/user/heartbeat.
     status: {
       type: String,
       enum: ["Online", "Idle", "Busy", "Offline"],
       default: "Offline",
     },
     activity: { type: String, default: "" },
+    // Updated every ~30s by the client heartbeat while the page is visible.
+    // Used to derive Online (<2 min) / Idle (<10 min) / Offline.
+    lastSeen: { type: Date, default: Date.now, index: true },
 
     // Legacy: Appwrite user ID (kept for any pre-migration users).
     // Sparse index allows multiple null values while preserving uniqueness.


### PR DESCRIPTION
## What's in this PR

- Presence heartbeat (lastSeen-based Online/Idle/Offline)
- Discord-style community chat (members rail, avatars, channel banner)
- Site-wide light-mode gradient
- /problems filter bar polish
- /Explore redesign (stats strip, list-style activity)
- /Dashboard redesign (3-col + Network widget)
- /playground LeetCode-style 2-col layout
- /Profile HistorySection: relative time + pass/fail icons
- Home page CTA + hydration fixes
- Scoring tiers: easy 10 / medium 20 / hard 35